### PR TITLE
added sanity checking for subspace sequences

### DIFF
--- a/gpmap/gpm.py
+++ b/gpmap/gpm.py
@@ -503,6 +503,11 @@ class GenotypePhenotypeMap(BaseMap):
         GenotypePhenotypeMap: obj
             Sub-GenotypePhenotypeMap between two sequences.
         """
+
+        if genotype2 != None and len(genotype1) != len(genotype2):
+            err = "genotypes must have the same length to calculate subspace.\n"
+            raise ValueError(err)
+
         # Construct the mutations dictionary if not given (assumes binary)
         if mutations is None:
             mutations = utils.binary_mutations_map(genotype1, genotype2)


### PR DESCRIPTION
Had a typo in one of my genotypes for gpm.subspace call.  (One sequence was seven aa, the other eight aa).  Threw uninformative error that took code-gazing to figure out (copied below).   Added length check that now throws informative error.  

New Error:
```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-10-0289952cee81> in <module>()
     50
     51
---> 52 gpm.subspace("MNKQNIR","METAQSIR")

/home/harmsm/Desktop/2017-01-11_rowena-predicted-space/gpmap/gpmap/gpm.py in subspace(self, genotype1, genotype2, mutations)
    507         if genotype2 != None and len(genotype1) != len(genotype2):
    508             err = "genotypes must have the same length to calculate subspace.\n"
--> 509             raise ValueError(err)
    510
    511         # Construct the mutations dictionary if not given (assumes binary)

ValueError: genotypes must have the same length to calculate subspace.

```


Old Error:
```
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
<ipython-input-19-0289952cee81> in <module>()
     50
     51
---> 52 gpm.subspace("MNKQNIR","METAQSIR")

/home/harmsm/Desktop/2017-01-11_rowena-predicted-space/gpmap/gpmap/gpm.py in subspace(self, genotype1, genotype2, mutations)
    535             n_replicates=self.n_replicates,
    536             logbase=self.logbase)

/home/harmsm/Desktop/2017-01-11_rowena-predicted-space/gpmap/gpmap/gpm.py in __init__(self, wildtype, genotypes, phenotypes, stdeviations, log_transform, mutations, n_replicates, logbase, **kwargs)
    119         # Set initial properties fo GPM
    120         self.wildtype = wildtype
--> 121         self.genotypes = np.array(genotypes)
    122         self.log_transform = log_transform
    123         self.transformed = False

/home/harmsm/Desktop/2017-01-11_rowena-predicted-space/gpmap/gpmap/gpm.py in genotypes(self, genotypes)
    339         self._n = len(genotypes)
    340         self._length = len(genotypes[0])
--> 341         self._genotypes = np.array(genotypes)
    342         self._indices = np.arange(self.n)
    343

IndexError: index 0 is out of bounds for axis 0 with size 0
```

